### PR TITLE
Fix MacOS PrusaSlicer bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ followed by the path to this script
 and the path of the gcode file. Will overwrite the file.
 #### Option B) use it as a automatic post-processing script in PrusaSlicer
 1. open PrusaSlicer, go to print-settings-tab->output-options. Locate the window for post-processing-script. 
-2. In that window enter: `full-path-to-your-python-exe full-path-to-this-script`  (with blank space between the two paths!)
+2. In that window enter: `full/path/to/your/python.exe full/path/to/this/script/including/prusa_slicer_post_processing_script.py`  (with blank space between the two paths!)
 3. PrusaSlicer will execute the script after the export of the Gcode, therefore the view in PrusaSlicer wont change. 
 4. Open the finished gcode file to see the results.
 
@@ -53,7 +53,7 @@ If the python path contains any empty spaces, mask them as described here (using
 https://manual.slic3r.org/advanced/post-processing
 https://help.prusa3d.com/article/post-processing-scripts_283913
 
-Also, for unix like systems, you need to skip the user input to close the program. You can do it adding a `-y` at the end of the two paths, obtaining something like this: `full-path-to-your-python-exe full-path-to-this-script -y`
+Also, for unix like systems, you need to skip the user input to close the program. You can do it adding a `-y` at the end of the two paths, obtaining something like this: `full/path/to/your/python full/path/to/this/script/including/prusa_slicer_post_processing_script.py -y`
 
 If you want to change generation settings: Open the Script in an editor, scroll to 'Parameter' section. Settings from PrusaSlicer will be extracted automaticly from the gcode.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ and the path of the gcode file. Will overwrite the file.
 4. Open the finished gcode file to see the results.
 
 Notes to nail it first try:
-If the python path contains any empty spaces, mask them as described here: https://manual.slic3r.org/advanced/post-processing
+If the python path contains any empty spaces, mask them as described here (using "\ " on unix like sistems and "! " on windows): 
+https://manual.slic3r.org/advanced/post-processing
+https://help.prusa3d.com/article/post-processing-scripts_283913
 
 If you want to change generation settings: Open the Script in an editor, scroll to 'Parameter' section. Settings from PrusaSlicer will be extracted automaticly from the gcode.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ followed by the path to this script
 and the path of the gcode file. Will overwrite the file.
 #### Option B) use it as a automatic post-processing script in PrusaSlicer
 1. open PrusaSlicer, go to print-settings-tab->output-options. Locate the window for post-processing-script. 
-2. In that window enter: `full/path/to/your/python.exe full/path/to/this/script/including/prusa_slicer_post_processing_script.py`  (with blank space between the two paths!)
+2. In that window enter: `C:\full\path\to\your\python.exe C:\full\path\to\this\script\including\prusa_slicer_post_processing_script.py`  (with blank space between the two paths!)
 3. PrusaSlicer will execute the script after the export of the Gcode, therefore the view in PrusaSlicer wont change. 
 4. Open the finished gcode file to see the results.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ followed by the path to this script
 and the path of the gcode file. Will overwrite the file.
 #### Option B) use it as a automatic post-processing script in PrusaSlicer
 1. open PrusaSlicer, go to print-settings-tab->output-options. Locate the window for post-processing-script. 
-2. In that window enter: full-path-to-your-python-exe full-path-to-this-script-incl-filename  (with blank space between the two paths!)
+2. In that window enter: `full-path-to-your-python-exe full-path-to-this-script`  (with blank space between the two paths!)
 3. PrusaSlicer will execute the script after the export of the Gcode, therefore the view in PrusaSlicer wont change. 
 4. Open the finished gcode file to see the results.
 
@@ -52,6 +52,8 @@ Notes to nail it first try:
 If the python path contains any empty spaces, mask them as described here (using "\ " on unix like sistems and "! " on windows): 
 https://manual.slic3r.org/advanced/post-processing
 https://help.prusa3d.com/article/post-processing-scripts_283913
+
+Also, for unix like systems, you need to skip the user input to close the program. You can do it adding a `-y` at the end of the two paths, obtaining something like this: `full-path-to-your-python-exe full-path-to-this-script -y`
 
 If you want to change generation settings: Open the Script in an editor, scroll to 'Parameter' section. Settings from PrusaSlicer will be extracted automaticly from the gcode.
 

--- a/prusa_slicer_post_processing_script.py
+++ b/prusa_slicer_post_processing_script.py
@@ -374,7 +374,6 @@ def main(gCodeFileStream,path2GCode)->None:
         print(f"Analysed {len(layerobjs)} Layers, but no matching overhangs found->no arcs generated. If unexpected: look if restricting settings like 'minArea' or 'MinBridgeLength' are correct.")     
     #os.startfile(path2GCode, 'open')
     print("Script execution complete.")
-    input("Push enter to close this window")
 
 ################################# HELPER FUNCTIONS GCode->Polygon #################################
 ###################################################################################################

--- a/prusa_slicer_post_processing_script.py
+++ b/prusa_slicer_post_processing_script.py
@@ -101,7 +101,7 @@ def makeFullSettingDict(gCodeSettingDict:dict) -> dict:
 ################################# MAIN FUNCTION #################################
 #################################################################################    
 #at the top, for better reading
-def main(gCodeFileStream,path2GCode)->None:
+def main(gCodeFileStream,path2GCode,skipInput)->None:
     '''Here all the work is done, therefore it is much to long.'''
     gCodeLines=gCodeFileStream.readlines()
     gCodeSettingDict=readSettingsFromGCode2dict(gCodeLines)
@@ -374,21 +374,29 @@ def main(gCodeFileStream,path2GCode)->None:
         print(f"Analysed {len(layerobjs)} Layers, but no matching overhangs found->no arcs generated. If unexpected: look if restricting settings like 'minArea' or 'MinBridgeLength' are correct.")     
     #os.startfile(path2GCode, 'open')
     print("Script execution complete.")
+    if not skipInput:
+        input("Press enter to exit.")
 
 ################################# HELPER FUNCTIONS GCode->Polygon #################################
 ###################################################################################################
 
 def getFileStreamAndPath(read=True):
-    if len(sys.argv) != 2:
-        print("Usage: python3 ex1.py <filename>")
-        sys.exit(1)
-    filepath = sys.argv[1]
+    skipInput=False
+    if len(sys.argv) > 2:
+        if sys.argv[1] != '-y':
+            print("Usage: python3 ex1.py <filename>")
+            sys.exit(1)
+        else:
+            skipInput=True
+            filepath = sys.argv[2]
+    else:
+        filepath = sys.argv[1]
     try:
         if read:
             f = open(filepath, "r")
         else:
             f=open(filepath, "w")    
-        return f,filepath
+        return f,filepath,skipInput
     except IOError:
         input("File not found.Press enter.")
         sys.exit(1)
@@ -1162,7 +1170,6 @@ warnings.showwarning = _warning
 
 ################################# MAIN EXECUTION #################################
 ##################################################################################
-
 if __name__=="__main__":
-    gCodeFileStream,path2GCode = getFileStreamAndPath()
-    main(gCodeFileStream,path2GCode)
+    gCodeFileStream,path2GCode, skipInput = getFileStreamAndPath()
+    main(gCodeFileStream,path2GCode, skipInput)


### PR DESCRIPTION
Deleting the line to close the program and letting it close itself automatically, i fixed the EOF error that occurred in PrusaSlicer on MacOS. Fix #11 issue
Some other instructions to use white spaces in paths both on unix like systems and windows