### PR TITLE
added cli args and help

### DIFF
--- a/prusa_slicer_post_processing_script.py
+++ b/prusa_slicer_post_processing_script.py
@@ -26,6 +26,7 @@ Known issues:
 #!/usr/bin/python
 import sys
 import os
+import argparse
 from shapely import Point, Polygon, LineString, GeometryCollection, MultiLineString, MultiPolygon
 from shapely.ops import nearest_points
 from shapely.ops import linemerge, unary_union
@@ -37,7 +38,6 @@ import random
 import platform
 #from hilbertcurve.hilbertcurve import HilbertCurve
 from hilbert import decode, encode
-import argparse
 ########## Parameters  - adjust values here as needed ##########
 def makeFullSettingDict(gCodeSettingDict:dict) -> dict: 
     """Merge Two Dictionarys and set some keys/values explicitly"""
@@ -1192,7 +1192,7 @@ warnings.showwarning = _warning
 ##################################################################################
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Process G-code files.")
+    parser = argparse.ArgumentParser(description="Process overhangs within PrusaSlicer G-code files into circular arcs.")
     parser.add_argument('path', type=str, help='Path to the G-code file')
     parser.add_argument('--skip-input', action='store_true', help='Skip any user input prompts (non-Windows only)')
     return parser.parse_args()

--- a/prusa_slicer_post_processing_script.py
+++ b/prusa_slicer_post_processing_script.py
@@ -37,6 +37,7 @@ import random
 import platform
 #from hilbertcurve.hilbertcurve import HilbertCurve
 from hilbert import decode, encode
+import argparse
 ########## Parameters  - adjust values here as needed ##########
 def makeFullSettingDict(gCodeSettingDict:dict) -> dict: 
     """Merge Two Dictionarys and set some keys/values explicitly"""
@@ -1189,9 +1190,21 @@ warnings.showwarning = _warning
 
 ################################# MAIN EXECUTION #################################
 ##################################################################################
-if __name__=="__main__":
-    gCodeFileStream,path2GCode = getFileStreamAndPath()
-    skipInput=False
-    if platform.system()!="Windows":
-        skipInput=True
-    main(gCodeFileStream,path2GCode, skipInput)
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Process G-code files.")
+    parser.add_argument('path', type=str, help='Path to the G-code file')
+    parser.add_argument('--skip-input', action='store_true', help='Skip any user input prompts (non-Windows only)')
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    # Get file stream and path based on the provided path
+    gCodeFileStream, path2GCode = getFileStreamAndPath(args.path)
+
+    # Determine whether to skip input based on the platform and command line argument
+    skipInput = args.skip_input or platform.system() != "Windows"
+
+    # Call the main function with the arguments
+    main(gCodeFileStream, path2GCode, skipInput)


### PR DESCRIPTION
Description:
This pull request integrates argument parsing into the G-code processing script, making it more user-friendly and adaptable for automation. It adds support for a mandatory file path as a positional argument and an optional --skip-input flag for non-interactive environments.

Key Changes:
Positional Argument: Users must specify the G-code file path directly when executing the script.
Optional Flag: The --skip-input flag allows users to bypass manual input prompts.
Help Output: Enhanced help documentation is available to assist with new command-line options.

Behavior:
Running with Arguments: python prusa_slicer_post_processing_script.py /path/to/your/file.gcode
Skipping Input Prompts: python prusa_slicer_post_processing_script.py /path/to/your/file.gcode --skip-input
Accessing Help: python prusa_slicer_post_processing_script.py --help

No Arguments Provided: If the script is run without any arguments, it will display an error message and the usage information to help guide the user on how to properly execute the script.
