### PR TITLE
Skipping the first deretraction

### DIFF
--- a/prusa_slicer_post_processing_script.py
+++ b/prusa_slicer_post_processing_script.py
@@ -276,15 +276,13 @@ def main(gCodeFileStream,path2GCode,skipInput)->None:
                         #    plot_geometry(Point(arc.coords[0]))
                         #plt.axis('square')
                         #plt.show()
-                        #remove empty arcs
-                        arcs4gcode = [x for x in arcs4gcode if not x.is_empty]
                         for ida,arc in enumerate(arcs4gcode):
-                            final_arc = ida == len(arcs4gcode) - 1
-                            arcGCode=arc2GCode(arcline=arc,eStepsPerMM=eStepsPerMM,arcidx=ida,final_arc=final_arc,kwargs=parameters)
-                            arcOverhangGCode.append(arcGCode)
-                            if parameters.get("TimeLapseEveryNArcs")>0:
-                                if ida%parameters.get("TimeLapseEveryNArcs"):
-                                    arcOverhangGCode.append("M240\n")
+                            if not arc.is_empty:    
+                                arcGCode=arc2GCode(arcline=arc,eStepsPerMM=eStepsPerMM,arcidx=ida,kwargs=parameters)
+                                arcOverhangGCode.append(arcGCode)
+                                if parameters.get("TimeLapseEveryNArcs")>0:
+                                    if ida%parameters.get("TimeLapseEveryNArcs"):
+                                        arcOverhangGCode.append("M240\n")
 
                 #apply special cooling settings:    
                 if len(layer.oldpolys)>0:
@@ -1137,7 +1135,7 @@ def retractGCode(retract:bool=True,kwargs:dict={})->str:
 def setFeedRateGCode(F:int)->str:
     return f"G1 F{F}\n"     
 
-def arc2GCode(arcline:LineString,eStepsPerMM:float,arcidx=None,final_arc=None,kwargs={})->list:
+def arc2GCode(arcline:LineString,eStepsPerMM:float,arcidx=None,kwargs={})->list:
     GCodeLines=[]
     p1=None
     pts=[Point(p) for p in arcline.coords]
@@ -1166,8 +1164,7 @@ def arc2GCode(arcline:LineString,eStepsPerMM:float,arcidx=None,final_arc=None,kw
                 p1=p
         if idp==len(pts)-1:
             GCodeLines.append(p2GCode(pExtend,E=extDist*eStepsPerMM))#extend arc tangentially for better bonding between arcs
-            if not final_arc:
-                GCodeLines.append(retractGCode(retract=True,kwargs=kwargs))
+            GCodeLines.append(retractGCode(retract=True,kwargs=kwargs))
     return GCodeLines        
 
 def hilbert2GCode(allhilbertpts:list,parameters:dict,layerheight:float):

--- a/prusa_slicer_post_processing_script.py
+++ b/prusa_slicer_post_processing_script.py
@@ -276,13 +276,15 @@ def main(gCodeFileStream,path2GCode,skipInput)->None:
                         #    plot_geometry(Point(arc.coords[0]))
                         #plt.axis('square')
                         #plt.show()
+                        #remove empty arcs
+                        arcs4gcode = [x for x in arcs4gcode if not x.is_empty]
                         for ida,arc in enumerate(arcs4gcode):
-                            if not arc.is_empty:    
-                                arcGCode=arc2GCode(arcline=arc,eStepsPerMM=eStepsPerMM,arcidx=ida,kwargs=parameters)
-                                arcOverhangGCode.append(arcGCode)
-                                if parameters.get("TimeLapseEveryNArcs")>0:
-                                    if ida%parameters.get("TimeLapseEveryNArcs"):
-                                        arcOverhangGCode.append("M240\n")
+                            final_arc = ida == len(arcs4gcode) - 1
+                            arcGCode=arc2GCode(arcline=arc,eStepsPerMM=eStepsPerMM,arcidx=ida,final_arc=final_arc,kwargs=parameters)
+                            arcOverhangGCode.append(arcGCode)
+                            if parameters.get("TimeLapseEveryNArcs")>0:
+                                if ida%parameters.get("TimeLapseEveryNArcs"):
+                                    arcOverhangGCode.append("M240\n")
 
                 #apply special cooling settings:    
                 if len(layer.oldpolys)>0:
@@ -1135,7 +1137,7 @@ def retractGCode(retract:bool=True,kwargs:dict={})->str:
 def setFeedRateGCode(F:int)->str:
     return f"G1 F{F}\n"     
 
-def arc2GCode(arcline:LineString,eStepsPerMM:float,arcidx=None,kwargs={})->list:
+def arc2GCode(arcline:LineString,eStepsPerMM:float,arcidx=None,final_arc=None,kwargs={})->list:
     GCodeLines=[]
     p1=None
     pts=[Point(p) for p in arcline.coords]
@@ -1164,7 +1166,8 @@ def arc2GCode(arcline:LineString,eStepsPerMM:float,arcidx=None,kwargs={})->list:
                 p1=p
         if idp==len(pts)-1:
             GCodeLines.append(p2GCode(pExtend,E=extDist*eStepsPerMM))#extend arc tangentially for better bonding between arcs
-            GCodeLines.append(retractGCode(retract=True,kwargs=kwargs))
+            if not final_arc:
+                GCodeLines.append(retractGCode(retract=True,kwargs=kwargs))
     return GCodeLines        
 
 def hilbert2GCode(allhilbertpts:list,parameters:dict,layerheight:float):

--- a/prusa_slicer_post_processing_script.py
+++ b/prusa_slicer_post_processing_script.py
@@ -1150,6 +1150,7 @@ def arc2GCode(arcline:LineString,eStepsPerMM:float,arcidx=None,kwargs={})->list:
                             kwargs.get("ArcMinPrintSpeed",1*60),kwargs.get('ArcPrintSpeed',2*60)) # *60 bc unit conversion:mm/s=>mm/min
     for idp,p in enumerate(pts):
         if idp==0:
+            GCodeLines.append(retractGCode(retract=True,kwargs=kwargs))
             p1=p
             GCodeLines.append(f";Arc {arcidx if arcidx else ' '} Length:{arcline.length}\n")
             GCodeLines.append(p2GCode(p,F=kwargs.get('ArcTravelFeedRate',100*60)))#feedrate is mm/min...
@@ -1162,7 +1163,6 @@ def arc2GCode(arcline:LineString,eStepsPerMM:float,arcidx=None,kwargs={})->list:
                 p1=p
         if idp==len(pts)-1:
             GCodeLines.append(p2GCode(pExtend,E=extDist*eStepsPerMM))#extend arc tangentially for better bonding between arcs
-            GCodeLines.append(retractGCode(retract=True,kwargs=kwargs))
     return GCodeLines        
 
 def hilbert2GCode(allhilbertpts:list,parameters:dict,layerheight:float):

--- a/prusa_slicer_post_processing_script.py
+++ b/prusa_slicer_post_processing_script.py
@@ -1153,9 +1153,7 @@ def arc2GCode(arcline:LineString,eStepsPerMM:float,arcidx=None,kwargs={})->list:
             p1=p
             GCodeLines.append(f";Arc {arcidx if arcidx else ' '} Length:{arcline.length}\n")
             GCodeLines.append(p2GCode(p,F=kwargs.get('ArcTravelFeedRate',100*60)))#feedrate is mm/min...
-            # Skip the first deretraction, assume slicer added it for layer change or travel
-            if arcidx > 0:    
-                GCodeLines.append(retractGCode(retract=False,kwargs=kwargs))
+            GCodeLines.append(retractGCode(retract=False,kwargs=kwargs))
             GCodeLines.append(setFeedRateGCode(arcPrintSpeed))
         else:
             dist=p.distance(p1)

--- a/prusa_slicer_post_processing_script.py
+++ b/prusa_slicer_post_processing_script.py
@@ -1153,7 +1153,9 @@ def arc2GCode(arcline:LineString,eStepsPerMM:float,arcidx=None,kwargs={})->list:
             p1=p
             GCodeLines.append(f";Arc {arcidx if arcidx else ' '} Length:{arcline.length}\n")
             GCodeLines.append(p2GCode(p,F=kwargs.get('ArcTravelFeedRate',100*60)))#feedrate is mm/min...
-            GCodeLines.append(retractGCode(retract=False,kwargs=kwargs))
+            # Skip the first deretraction, assume slicer added it for layer change or travel
+            if arcidx > 0:    
+                GCodeLines.append(retractGCode(retract=False,kwargs=kwargs))
             GCodeLines.append(setFeedRateGCode(arcPrintSpeed))
         else:
             dist=p.distance(p1)


### PR DESCRIPTION
Description:
This pull request addresses a specific issue where a double deretraction occurs at the start of an arc movement, identified in issue #80. The change ensures that the first deretraction command before any new arc infill is skipped, under the assumption that it is automatically added by the slicer during layer changes or travel moves.

Changes Made:
Code Modification: Updated the logic to conditionally append deretraction commands based on the arc index. If arcidx (the index of the current arc segment being processed) is greater than 0, the script appends a deretraction command. This prevents the initial unwanted deretraction that occurs when the arc index is 0, likely introduced automatically by the slicer.